### PR TITLE
Debriefing screen text alignment

### DIFF
--- a/src/fedebrief.c
+++ b/src/fedebrief.c
@@ -402,7 +402,7 @@ void draw_mission_people_stats_names_column(struct ScreenBox *box,
     lnheight = fheight + 4;
 
     // Row with names
-    x = 10;
+    x = 20;
     y = lnheight;
 
     draw_text_purple_list2(x, y, gui_strings[618], 0);


### PR DESCRIPTION
Makes the left side of the text in the two main boxes align nicely.

By default the text in the upper box is further to the right compared to the lower box, this is consistent with the original game. My OCD dictates that this cannot stand, so I'm moving the text in the lower box further inwards.

Left old, right new:
![debrief](https://github.com/swfans/swars/assets/107389189/7eda05ad-620a-4368-a21e-75ecf45d8e2a)

My first PR changing exactly 1 character 😅