### PR TITLE
move item pickup position

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -3127,7 +3127,7 @@ TbBool draw_panel_pickable_thing_below_agent(struct Thing *p_agent)
             if (weptype)
                 draw_new_panel_sprite_std(548, 364, weapon_defs[weptype].Sprite & 0xFF);
             else
-                draw_new_panel_sprite_std(540, 360, 70);
+                draw_new_panel_sprite_std(548, 364, 70);
             draw_new_panel_sprite_std(540, 360, 12);
             drawn = true;
         } else {


### PR DESCRIPTION
Attempts to fix https://github.com/swfans/swars/issues/126
This should move the non-weapon "standing on" pickup to the same position as the mouseover pickup.