### PR TITLE
Center window on resize with SDL_VIDEO_CENTERED

### DIFF
--- a/bflibrary/src/x86-win-sdl2/sscreen.c
+++ b/bflibrary/src/x86-win-sdl2/sscreen.c
@@ -432,6 +432,14 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
     // SDL video mode flags
     LbIGetSDLFlagsForMode(&sdlFlags, &sdlPxFormat, mdinfo);
 
+    // Set window position
+    int windowpos;
+    windowpos = SDL_WINDOWPOS_UNDEFINED;
+
+    // Check for SDL_VIDEO_CENTERED system variable
+    if (SDL_GetHintBoolean("SDL_VIDEO_CENTERED", SDL_FALSE))
+        windowpos = SDL_WINDOWPOS_CENTERED;
+
     // Note:
     // We set the window's fullscreen state (either Window, Fullscreen, or Fake Fullscreen)
     // We set the DisplayMode for real fullscreen mode
@@ -480,17 +488,14 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
         if (new_fullscreen_flags == 0)
         {
             SDL_SetWindowSize(lbWindow, mdWidth, mdHeight);
-            if ((SDL_getenv("SDL_VIDEO_CENTERED")) && (strcmp((SDL_getenv("SDL_VIDEO_CENTERED")), "1") == 0))
-            {
-                SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-            }
+            if (windowpos != SDL_WINDOWPOS_UNDEFINED)
+                SDL_SetWindowPosition(lbWindow, windowpos, windowpos);
         }
     }
 
     // Set SDL video mode and create window, if not created before
     if (lbWindow == NULL) {
-        lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_UNDEFINED,
-          SDL_WINDOWPOS_UNDEFINED, mdWidth, mdHeight, sdlFlags);
+        lbWindow = SDL_CreateWindow(lbDrawAreaTitle, windowpos, windowpos, mdWidth, mdHeight, sdlFlags);
     }
 
     if (lbWindow == NULL) {

--- a/bflibrary/src/x86-win-sdl2/sscreen.c
+++ b/bflibrary/src/x86-win-sdl2/sscreen.c
@@ -383,6 +383,7 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
     const struct TbSprite *msspr;
     TbScreenModeInfo *mdinfo;
     ulong sdlFlags, sdlPxFormat;
+    int windowpos;
 
     msspr = NULL;
     LbExeReferenceNumber();
@@ -432,11 +433,8 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
     // SDL video mode flags
     LbIGetSDLFlagsForMode(&sdlFlags, &sdlPxFormat, mdinfo);
 
-    // Set window position
-    int windowpos;
+    // Set window position depending on SDL_VIDEO_CENTERED system variable
     windowpos = SDL_WINDOWPOS_UNDEFINED;
-
-    // Check for SDL_VIDEO_CENTERED system variable
     if (SDL_GetHintBoolean("SDL_VIDEO_CENTERED", SDL_FALSE))
         windowpos = SDL_WINDOWPOS_CENTERED;
 

--- a/bflibrary/src/x86-win-sdl2/sscreen.c
+++ b/bflibrary/src/x86-win-sdl2/sscreen.c
@@ -480,10 +480,10 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
         if (new_fullscreen_flags == 0)
         {
             SDL_SetWindowSize(lbWindow, mdWidth, mdHeight);
-            if (strcmp((SDL_getenv("SDL_VIDEO_CENTERED")), "1") == 0)
-            {
-                SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-            }
+			if (SDL_getenv("SDL_VIDEO_CENTERED")) && (strcmp((SDL_getenv("SDL_VIDEO_CENTERED")), "1") == 0)
+			{
+				SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+			}
         }
     }
 

--- a/bflibrary/src/x86-win-sdl2/sscreen.c
+++ b/bflibrary/src/x86-win-sdl2/sscreen.c
@@ -480,7 +480,7 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
         if (new_fullscreen_flags == 0)
         {
             SDL_SetWindowSize(lbWindow, mdWidth, mdHeight);
-            if (SDL_getenv("SDL_VIDEO_CENTERED")) && (strcmp((SDL_getenv("SDL_VIDEO_CENTERED")), "1") == 0)
+            if ((SDL_getenv("SDL_VIDEO_CENTERED")) && (strcmp((SDL_getenv("SDL_VIDEO_CENTERED")), "1") == 0))
             {
                 SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
             }

--- a/bflibrary/src/x86-win-sdl2/sscreen.c
+++ b/bflibrary/src/x86-win-sdl2/sscreen.c
@@ -480,6 +480,7 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
         if (new_fullscreen_flags == 0)
         {
             SDL_SetWindowSize(lbWindow, mdWidth, mdHeight);
+            SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
         }
     }
 

--- a/bflibrary/src/x86-win-sdl2/sscreen.c
+++ b/bflibrary/src/x86-win-sdl2/sscreen.c
@@ -480,7 +480,10 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
         if (new_fullscreen_flags == 0)
         {
             SDL_SetWindowSize(lbWindow, mdWidth, mdHeight);
-            SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+            if (strcmp((SDL_getenv("SDL_VIDEO_CENTERED")), "1") == 0)
+            {
+                SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+            }
         }
     }
 

--- a/bflibrary/src/x86-win-sdl2/sscreen.c
+++ b/bflibrary/src/x86-win-sdl2/sscreen.c
@@ -480,10 +480,10 @@ TbResult LbScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
         if (new_fullscreen_flags == 0)
         {
             SDL_SetWindowSize(lbWindow, mdWidth, mdHeight);
-			if (SDL_getenv("SDL_VIDEO_CENTERED")) && (strcmp((SDL_getenv("SDL_VIDEO_CENTERED")), "1") == 0)
-			{
-				SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-			}
+            if (SDL_getenv("SDL_VIDEO_CENTERED")) && (strcmp((SDL_getenv("SDL_VIDEO_CENTERED")), "1") == 0)
+            {
+                SDL_SetWindowPosition(lbWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+            }
         }
     }
 


### PR DESCRIPTION
Took me a while to figure it out, but it should work as expected now. Only tested on Windows.

- If there's a `SDL_VIDEO_CENTERED` system variable with a value of 1, the SDL2 version should now work like the SDL1 version and always center the window when resolution or aspect ratio changes.
- If it doesn't exist or isn't 1, nothing should change.

Fixes https://github.com/swfans/swars/issues/200