### PR TITLE
syndwarsfx: 32bit joybuttons + enable MORE_GAME_KEYS

### DIFF
--- a/src/fecntrls.c
+++ b/src/fecntrls.c
@@ -326,7 +326,7 @@ ubyte show_controls_joystick_box(struct ScreenBox *p_box)
     return 0;
 }
 
-void set_controls_key(ushort hlight_gkey, ushort key)
+void set_controls_key(ushort hlight_gkey, uint32_t key)
 {
     GameKey gkey;
     TbBool is_joystick;
@@ -547,7 +547,7 @@ ubyte menu_controls_inputs(struct ScreenTextBox *p_box, short *p_tx_kbd_width, s
         {
             if (is_joy_pressed_any(0))
             {
-                ushort jskey;
+                JoyButtonSet jskey;
 
                 jskey = get_joy_pressed_key(0);
                 set_controls_key(edited_gkey, jskey);

--- a/src/game.c
+++ b/src/game.c
@@ -4959,7 +4959,6 @@ ubyte weapon_select_input(void)
         }
     }
 
-#ifdef MORE_GAME_KEYS
     if (is_gamekey_pressed(GKey_SUPERSHIELD))
     {
         clear_gamekey_pressed(GKey_SUPERSHIELD);
@@ -4979,7 +4978,6 @@ ubyte weapon_select_input(void)
             return GINPUT_PACKET;
         }
     }
-#endif
 
     assert(sizeof(sel_weapon_gkeys)/sizeof(sel_weapon_gkeys[0]) <= WEAPONS_CARRIED_MAX_COUNT);
 

--- a/src/game_bstype.h
+++ b/src/game_bstype.h
@@ -60,6 +60,11 @@ typedef short ScrCoord;
  */
 typedef ushort GameKey;
 
+/**
+ *  store a set of joystick buttons pressed.
+ */
+typedef uint32_t JoyButtonSet;
+
 /** Type which stores coordinate on the ingame map.
  *
  * Can be separated into a tile and position within.

--- a/src/game_save.c
+++ b/src/game_save.c
@@ -285,29 +285,34 @@ void read_user_settings(void)
             LbFileRead(fh, &fmtver, sizeof(u32));
         else
             fmtver = 0;
-
+            
         if (fmtver == 0) {
             // In original game, the last key (agent 4 select) is not saved at all
             set_default_game_keys();
+            ushort jskeys_old[23];
             LbFileRead(fh, kbkeys, 23 * sizeof(ushort));
-            LbFileRead(fh, jskeys, 23 * sizeof(ushort));
+            LbFileRead(fh, jskeys_old, 23 * sizeof(ushort));
+            for (i = 0; i < 23; i++)
+                jskeys[i] = jskeys_old[i];
         } else if (fmtver == 1) {
             set_default_game_keys();
+            ushort jskeys_old[29];
             LbFileRead(fh, kbkeys, 29 * sizeof(ushort));
-            LbFileRead(fh, jskeys, 29 * sizeof(ushort));
+            LbFileRead(fh, jskeys_old, 29 * sizeof(ushort));
+            for (i = 0; i < 29; i++)
+                jskeys[i] = jskeys_old[i];
         } else if (fmtver == 2) {
             set_default_game_keys();
+            ushort jskeys_old[50];
             LbFileRead(fh, kbkeys, 50 * sizeof(ushort));
-            LbFileRead(fh, jskeys, 50 * sizeof(ushort));
+            LbFileRead(fh, jskeys_old, 50 * sizeof(ushort));
+            for (i = 0; i < 50; i++)
+                jskeys[i] = jskeys_old[i];
         } else {
-#ifdef MORE_GAME_KEYS
             if (fmtver != 3)
-#else
-            if (fmtver != 2)
-#endif
                 LOGWARN("Settings may be invalid, as \"%s\" has unrecognized format version %d", fname, (int)fmtver);
             LbFileRead(fh, kbkeys, GKey_KEYS_COUNT * sizeof(ushort));
-            LbFileRead(fh, jskeys, GKey_KEYS_COUNT * sizeof(ushort));
+            LbFileRead(fh, jskeys, GKey_KEYS_COUNT * sizeof(uint32_t));
         }
 
         LbFileRead(fh, &ctl_joystick_type, sizeof(ctl_joystick_type));
@@ -365,11 +370,7 @@ TbBool save_user_settings(void)
     int i;
 
     get_user_settings_fname(fname, login_name);
-#ifdef MORE_GAME_KEYS
     fmtver = 3;
-#else
-    fmtver = 2;
-#endif
 
     fh = LbFileOpen(fname, Lb_FILE_MODE_NEW);
     if (fh == INVALID_FILE)
@@ -377,7 +378,7 @@ TbBool save_user_settings(void)
 
     LbFileWrite(fh, &fmtver, sizeof(fmtver));
     LbFileWrite(fh, kbkeys, GKey_KEYS_COUNT * sizeof(ushort));
-    LbFileWrite(fh, jskeys, GKey_KEYS_COUNT * sizeof(ushort));
+    LbFileWrite(fh, jskeys, GKey_KEYS_COUNT * sizeof(uint32_t));
     LbFileWrite(fh, &ctl_joystick_type, sizeof(ctl_joystick_type));
     LbFileWrite(fh, &players[local_player_no].DoubleMode,
       sizeof(players[local_player_no].DoubleMode));

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -40,7 +40,7 @@
 
 ushort kbkeys[GKey_KEYS_COUNT];
 
-ushort jskeys[GKey_KEYS_COUNT];
+JoyButtonSet jskeys[GKey_KEYS_COUNT];
 
 ulong buffered_keys[KEYBOARD_BUFFER_SIZE];
 ulong buffered_keys_read_index;
@@ -86,7 +86,7 @@ void simulate_key_press(TbKeyCode key)
     }
 }
 
-ubyte is_joy_pressed(ushort jkeys, ubyte channel)
+ubyte is_joy_pressed(JoyButtonSet jkeys, ubyte channel)
 {
     return (jkeys && jkeys == joy.Buttons[channel]);
 }
@@ -96,11 +96,11 @@ ubyte is_joy_pressed_any(ubyte channel)
     return (joy.Buttons[channel] != 0);
 }
 
-ushort get_joy_pressed_key(ubyte channel)
+JoyButtonSet get_joy_pressed_key(ubyte channel)
 {
     uint jbtn_pressed;
     ushort jbtn, buttons_num, pressed_count;
-    ushort jskey_flags;
+    JoyButtonSet jskey_flags;
 
     jskey_flags = 0;
     buttons_num = joy.NumberOfButtons[channel];
@@ -118,14 +118,14 @@ ushort get_joy_pressed_key(ubyte channel)
     return jskey_flags;
 }
 
-void clear_joy_pressed(ushort jkeys, ubyte channel)
+void clear_joy_pressed(JoyButtonSet jkeys, ubyte channel)
 {
     if (channel >= sizeof(joy.Buttons[0])/sizeof(joy.Buttons[0]))
         return;
     joy.Buttons[channel] &= ~jkeys;
 }
 
-void sprint_joy_key(char *ostr, int buttons_num, ushort jkeys)
+void sprint_joy_key(char *ostr, int buttons_num, JoyButtonSet jkeys)
 {
     int tx_len;
     ushort jbtn, pressed_count;
@@ -197,7 +197,7 @@ ubyte is_gamekey_kbd_pressed(GameKey gkey)
 
 ubyte is_gamekey_joy_pressed(GameKey gkey, ubyte channel)
 {
-    ushort jkeys;
+    JoyButtonSet jkeys;
 
     jkeys = jskeys[gkey];
 
@@ -219,7 +219,7 @@ void clear_gamekey_kbd_pressed(GameKey gkey)
 
 void clear_gamekey_joy_pressed(GameKey gkey, ubyte channel)
 {
-    ushort jkeys;
+    JoyButtonSet jkeys;
 
     jkeys = jskeys[gkey];
     clear_joy_pressed(jkeys, channel);
@@ -242,7 +242,7 @@ void set_gamekey_kbd(GameKey gkey, TbKeyCode key)
     kbkeys[gkey] = key;
 }
 
-void set_gamekey_joy(GameKey gkey, ushort jkey)
+void set_gamekey_joy(GameKey gkey, JoyButtonSet jkey)
 {
     jskeys[gkey] = jkey;
 }
@@ -497,10 +497,8 @@ void set_default_game_keys(void)
     kbkeys[GKey_SEL_WEP_5] = KC_9;
     kbkeys[GKey_SEL_WEP_6] = KC_0;
     kbkeys[GKey_USE_MEDIKIT] = KC_UNASSIGNED;
-#ifdef MORE_GAME_KEYS
     kbkeys[GKey_SUPERSHIELD] = KC_UNASSIGNED;
     kbkeys[GKey_VIEW_THERMAL] = KC_UNASSIGNED;
-#endif
 }
 
 /******************************************************************************/

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -76,10 +76,8 @@ enum GameKeys
   GKey_SEL_WEP_5 = 47,
   GKey_SEL_WEP_6 = 48,
   GKey_USE_MEDIKIT = 49,
-#ifdef MORE_GAME_KEYS
   GKey_SUPERSHIELD = 50,
   GKey_VIEW_THERMAL = 51,
-#endif
   GKey_KEYS_COUNT,
 };
 
@@ -132,7 +130,7 @@ enum GameInputResult
 extern ushort kbkeys[GKey_KEYS_COUNT];
 /** Array of joystick button bindings; uses GKey_* enum members as index.
  */
-extern ushort jskeys[GKey_KEYS_COUNT];
+extern JoyButtonSet jskeys[GKey_KEYS_COUNT];
 /** Type of joystick selected with controls.
  */
 extern ubyte ctl_joystick_type;
@@ -158,7 +156,7 @@ ubyte is_key_pressed(TbKeyCode key, TbKeyMods kmodif);
  * @param jkeys Flags marking the buttons to check.
  * @param channel Joystick channel selection, for multiple joysticks connected.
  */
-ubyte is_joy_pressed(ushort jkeys, ubyte channel);
+ubyte is_joy_pressed(JoyButtonSet jkeys, ubyte channel);
 
 /**
  * Checks if any joystick key is pressed.
@@ -172,7 +170,7 @@ ubyte is_joy_pressed_any(ubyte channel);
  *
  * @param channel Joystick channel selection, for multiple joysticks connected.
  */
-ushort get_joy_pressed_key(ubyte channel);
+JoyButtonSet get_joy_pressed_key(ubyte channel);
 
 /**
  * Print joystick buttons combination as text.
@@ -181,7 +179,7 @@ ushort get_joy_pressed_key(ubyte channel);
  * @param buttons_num Amount of buttons supported by the device.
  * @param jkeys Flags marking the buttons to print.
  */
-void sprint_joy_key(char *ostr, int buttons_num, ushort jkeys);
+void sprint_joy_key(char *ostr, int buttons_num, JoyButtonSet jkeys);
 
 /**
  * Clears the marking that a specific key was pressed.
@@ -195,7 +193,7 @@ void simulate_key_press(TbKeyCode key);
  * @param jkeys Flags marking the buttons to clear.
  * @param channel Joystick channel selection, for multiple joysticks connected.
  */
-void clear_joy_pressed(ushort jkeys, ubyte channel);
+void clear_joy_pressed(JoyButtonSet jkeys, ubyte channel);
 
 /**
  * Checks if a mapped game key is pressed.
@@ -223,7 +221,7 @@ void set_gamekey_kbd(GameKey gkey, TbKeyCode key);
 /**
  * Set new joystick key assigned to the game key.
  */
-void set_gamekey_joy(GameKey gkey, ushort jkey);
+void set_gamekey_joy(GameKey gkey, JoyButtonSet jkey);
 
 void sprint_gamekey_combination_joy(char *ostr, GameKey gkey);
 void sprint_gamekey_combination_kbd(char *ostr, GameKey gkey);

--- a/src/swars.sx
+++ b/src/swars.sx
@@ -14367,7 +14367,7 @@ GLOBAL_FUNC (ASM_do_rotate_map)	/* 0x036480 */
 		xor    %edi,%edi
 		test   %edx,%edx
 		jne    jump_365ff
-		mov    EXPORT_SYMBOL(jskeys)+6,%dx
+		mov    EXPORT_SYMBOL(jskeys)+12,%dx
 		mov    EXPORT_SYMBOL(joy)+0x900,%esi # joy.Buttons
 		and    %edx,%esi
 		cmp    %edx,%esi
@@ -14376,7 +14376,7 @@ GLOBAL_FUNC (ASM_do_rotate_map)	/* 0x036480 */
 	jump_365e9:
 		xor    %edx,%edx
 		mov    EXPORT_SYMBOL(joy)+0x900,%esi # joy.Buttons
-		mov    EXPORT_SYMBOL(jskeys)+8,%dx
+		mov    EXPORT_SYMBOL(jskeys)+16,%dx
 		and    %edx,%esi
 		cmp    %edx,%esi
 		jne    jump_365ff
@@ -17121,8 +17121,8 @@ GLOBAL_FUNC (ASM_joy_input)	/* 0x3DC68 */
 		je     jump_3dd5e
 		xor    %esi,%esi
 		xor    %ecx,%ecx
-		mov    EXPORT_SYMBOL(jskeys)+6,%si
-		mov    EXPORT_SYMBOL(jskeys)+8,%cx
+		mov    EXPORT_SYMBOL(jskeys)+12,%si
+		mov    EXPORT_SYMBOL(jskeys)+16,%cx
 		mov    EXPORT_SYMBOL(joy)+0x900(%ebx),%edi # joy.Buttons
 		or     %esi,%ecx
 		mov    EXPORT_SYMBOL(joy)+0x900,%ebp # joy.Buttons


### PR DESCRIPTION
makes sure there's enough space for all the joystick buttons on a regular gamecontroller, this changes the format for config saves, since MORE_GAME_KEYS also does that, might as well enable that at same time